### PR TITLE
Update AC_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-model], [1.0.1], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-base-model], [1.0.1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([yang-models])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Change the AC_INIT macro's package name parameter from opx-model to
opx-base-model to align with debian package name.