### PR TITLE
Update base-model build dependency to include CPS pkg without openapi…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-base-model], [3.146.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-base-model], [3.146.0+opx1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([yang-models])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-base-model (3.146.0+opx1) unstable; urgency=medium
+
+  * Update: Fix the build-dependency to get the CPS fix for openapi omission
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 31 Jul 2018 16:00:00 -0800
+
 opx-base-model (3.146.0) unstable; urgency=medium
 
   * Bugfix: Add proper error message for LAG member mode mismatch

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Dell EMC <ops-dev@lists.openswitch.net>
 Build-Depends:
- debhelper (>=9), dh-autoreconf, libopx-cps-dev (>= 3.6.2), opx-yang-utils-dev (>= 3.6.2), python-lxml, python-pkg-resources
+ debhelper (>=9), dh-autoreconf, libopx-cps-dev (>= 3.6.3+opx2), opx-yang-utils-dev (>= 3.6.2), python-lxml, python-pkg-resources
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-base-model
 Vcs-Git: https://github.com/open-switch/opx-base-model.git


### PR DESCRIPTION
Fix base-model build dependency  …
* Bugfix: Fix the build-dependency to get the CPS fix for openapi omission

Signed-off-by: Rakesh Datta <rakesh.datta@dell.com>